### PR TITLE
fix(user): changing user nickanme for registered and unregistered players #issue-24

### DIFF
--- a/src/components/users/UserEditCombinedDialog.vue
+++ b/src/components/users/UserEditCombinedDialog.vue
@@ -190,7 +190,7 @@ const handleClose = () => {
 
 const handleConfirm = async () => {
   if (!formRef.value) return
-  if (form.value.roles.length === 0) {
+  if (form.value.roles.length === 0 && !props.user.is_unregistered) {
     ElMessage.warning('Выберите хотя бы одну роль')
     return
   }
@@ -198,12 +198,14 @@ const handleConfirm = async () => {
   try {
     await formRef.value.validate()
     loading.value = true
-    
-    emit('confirm', {
-      userId: props.user.id,
-      nickname: form.value.nickname,
-      roles: form.value.roles
-    })
+
+    let apiData = { nickname: form.value.nickname }
+
+    if (!props.user.is_unregistered) {
+      apiData.roles = form.value.roles
+    }
+
+    emit('confirm', props.user.id, apiData)
     
     handleClose()
   } catch (error) {

--- a/src/views/UsersView.vue
+++ b/src/views/UsersView.vue
@@ -324,13 +324,11 @@ const getUserFullName = (user) => {
   return `${first} ${last}`.trim() || 'Без имени'
 }
 
-const updateUserData = async ({ userId, nickname, roles }) => {
+const updateUserData = async (userId, apiData) => {
   try {
     // Обновляем никнейм и роли через один запрос
-    await apiService.updateUser(userId, { 
-      nickname: nickname,
-      roles: roles 
-    })
+
+    await apiService.updateUser(userId, apiData)
     
     ElMessage.success('Данные пользователя обновлены')
     await loadUsers()


### PR DESCRIPTION
Фикс галочки в #24 

> При редактировании игрока если он unregistered_player, то UI не должен позволять ему менять роли + для unregistered_player передается роль, что де факто вызывает 400 с стороны бека и не дает менять ники пользакам