### PR TITLE
feat: typed fouls and server-side foul removal #issue-61

### DIFF
--- a/src/components/game/FoulBadges.vue
+++ b/src/components/game/FoulBadges.vue
@@ -1,0 +1,169 @@
+<template>
+  <div class="foul-badges">
+    <el-tooltip
+      v-for="foulType in foulTypes"
+      :key="foulType.foul_type"
+      :content="foulType.foul_type"
+      placement="top"
+    >
+      <div
+        class="foul-badge"
+        :class="[
+          `foul-badge--${foulType.foul_type}`,
+          {
+            'is-disabled': !isClickable(foulType.foul_type),
+            'is-warning': isWarning(foulType)
+          }
+        ]"
+        @click.stop="handleClick(foulType)"
+      >
+        <span class="foul-badge-count">{{ getCurrentFouls(foulType.foul_type) }}</span>
+        <span class="foul-badge-letter">{{ foulType.foul_type[0] }}</span>
+      </div>
+    </el-tooltip>
+  </div>
+</template>
+
+<script setup>
+import { apiService } from '@/services/api.js'
+
+const props = defineProps({
+  gameId: {
+    type: String,
+    required: true
+  },
+  // Игрок из состояния игры: box_id, is_in_game, fouls: [{ type, count }] на начало круга
+  player: {
+    type: Object,
+    required: true
+  },
+  // Типы фолов системы правил: [{ foul_type, removal_threshold }]
+  foulTypes: {
+    type: Array,
+    required: true
+  },
+  // Дельта фолов текущей фазы: [{ box_id, count_fouls, type }]
+  foulsSummary: {
+    type: Array,
+    required: true
+  }
+})
+
+const emit = defineEmits(['update:foulsSummary', 'saved'])
+
+// Фолы игрока на начало круга (из состояния игры)
+const getInitialFouls = (type) => {
+  return props.player.fouls?.find(f => f.type === type)?.count || 0
+}
+
+// Фолы, добавленные в текущей фазе
+const getPhaseDelta = (type) => {
+  const entry = props.foulsSummary.find(
+    f => f.box_id === props.player.box_id && f.type === type
+  )
+  return entry?.count_fouls || 0
+}
+
+const getCurrentFouls = (type) => {
+  return getInitialFouls(type) + getPhaseDelta(type)
+}
+
+// Выбывшему по фолам оставляем возможность откатить фолы текущей фазы
+const isClickable = (type) => {
+  return props.player.is_in_game || getPhaseDelta(type) > 0
+}
+
+const isWarning = (foulType) => {
+  return getCurrentFouls(foulType.foul_type) >= foulType.removal_threshold - 1
+}
+
+const handleClick = async (foulType) => {
+  const type = foulType.foul_type
+  if (!isClickable(type)) return
+
+  const initialFouls = getInitialFouls(type)
+  const currentFouls = getCurrentFouls(type)
+
+  // По достижении порога клик сбрасывает фолы, добавленные в этой фазе
+  const newTotalFouls = currentFouls >= foulType.removal_threshold
+    ? initialFouls
+    : currentFouls + 1
+  const countFouls = newTotalFouls - initialFouls
+
+  const foulsSummary = props.foulsSummary.filter(
+    f => !(f.box_id === props.player.box_id && f.type === type)
+  )
+  if (countFouls > 0) {
+    foulsSummary.push({
+      box_id: props.player.box_id,
+      count_fouls: countFouls,
+      type
+    })
+  }
+  emit('update:foulsSummary', foulsSummary)
+
+  // Отправляем обновленные фолы на сервер
+  try {
+    await apiService.patchGamePhase(props.gameId, {
+      fouls_summary: foulsSummary
+    })
+    emit('saved')
+  } catch (error) {
+    console.error('Failed to patch fouls_summary:', error)
+  }
+}
+</script>
+
+<style scoped>
+.foul-badges {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.foul-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+  color: white;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.3s;
+  user-select: none;
+}
+
+.foul-badge--regular {
+  background-color: #409eff;
+}
+
+.foul-badge--tech {
+  background-color: #9254de;
+}
+
+.foul-badge-letter {
+  font-size: 10px;
+  font-weight: 700;
+  opacity: 0.75;
+  text-transform: lowercase;
+}
+
+.foul-badge:hover:not(.is-disabled) {
+  transform: scale(1.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.foul-badge.is-warning {
+  background-color: #e6a23c;
+}
+
+.foul-badge.is-disabled {
+  background-color: #dcdfe6;
+  color: #909399;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/game/FoulsPanel.vue
+++ b/src/components/game/FoulsPanel.vue
@@ -9,23 +9,21 @@
         :class="{ 'foul-item-disabled': !player.is_in_game }"
       >
         <span class="foul-player-number">{{ player.box_id }}</span>
-        <div
-          class="fouls-badge"
-          :class="{
-            'is-disabled': !player.is_in_game,
-            'is-warning': getCurrentFouls(player) > 2
-          }"
-          @click.stop="handleFoulsClick(player)"
-        >
-          {{ getCurrentFouls(player) }}
-        </div>
+        <FoulBadges
+          :game-id="gameId"
+          :player="player"
+          :foul-types="foulTypes"
+          :fouls-summary="phaseData.fouls_summary || []"
+          @update:fouls-summary="handleFoulsSummaryUpdate"
+          @saved="emit('saved')"
+        />
       </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { apiService } from '@/services/api.js'
+import FoulBadges from './FoulBadges.vue'
 
 const props = defineProps({
   gameId: {
@@ -39,82 +37,20 @@ const props = defineProps({
   phaseData: {
     type: Object,
     required: true
+  },
+  foulTypes: {
+    type: Array,
+    required: true
   }
 })
 
-const emit = defineEmits(['update:phaseData'])
+const emit = defineEmits(['update:phaseData', 'saved'])
 
-// Получает текущее количество фолов для игрока
-const getCurrentFouls = (row) => {
-  const foulEntry = props.phaseData.fouls_summary?.find(f => f.box_id === row.box_id)
-  if (foulEntry) {
-    return (row.fouls || 0) + foulEntry.count_fouls
-  }
-  return row.fouls || 0
-}
-
-// Обработчик клика по бейджу фолов
-const handleFoulsClick = async (row) => {
-  if (!row.is_in_game) return
-
-  const currentFouls = getCurrentFouls(row)
-  const initialFouls = row.fouls || 0
-
-  let newTotalFouls
-  if (currentFouls === 4) {
-    newTotalFouls = initialFouls
-  } else {
-    newTotalFouls = currentFouls + 1
-  }
-
-  const countFouls = newTotalFouls - initialFouls
-
-  const fouls_summary = [...(props.phaseData.fouls_summary || [])]
-  const existingIndex = fouls_summary.findIndex(f => f.box_id === row.box_id)
-
-  if (countFouls === 0) {
-    if (existingIndex !== -1) {
-      fouls_summary.splice(existingIndex, 1)
-    }
-  } else {
-    const foulEntry = {
-      box_id: row.box_id,
-      count_fouls: countFouls
-    }
-    if (existingIndex !== -1) {
-      fouls_summary[existingIndex] = foulEntry
-    } else {
-      fouls_summary.push(foulEntry)
-    }
-  }
-
-  const removed_box_ids = [...(props.phaseData.removed_box_ids || [])]
-  if (newTotalFouls === 4) {
-    if (!removed_box_ids.includes(row.box_id)) {
-      removed_box_ids.push(row.box_id)
-    }
-  } else {
-    const removedIndex = removed_box_ids.indexOf(row.box_id)
-    if (removedIndex !== -1) {
-      removed_box_ids.splice(removedIndex, 1)
-    }
-  }
-
-  const updatedPhaseData = {
+const handleFoulsSummaryUpdate = (foulsSummary) => {
+  emit('update:phaseData', {
     ...props.phaseData,
-    fouls_summary,
-    removed_box_ids
-  }
-  emit('update:phaseData', updatedPhaseData)
-
-  // Отправляем обновленные фолы на сервер
-  try {
-    await apiService.patchGamePhase(props.gameId, {
-      fouls_summary
-    })
-  } catch (error) {
-    console.error('Failed to patch fouls_summary:', error)
-  }
+    fouls_summary: foulsSummary
+  })
 }
 </script>
 
@@ -162,41 +98,5 @@ const handleFoulsClick = async (row) => {
   font-size: 12px;
   font-weight: 600;
   color: #606266;
-}
-
-.fouls-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 24px;
-  height: 24px;
-  padding: 0 8px;
-  background-color: #409eff;
-  color: white;
-  border-radius: 12px;
-  font-weight: 600;
-  font-size: 14px;
-  cursor: pointer;
-  transition: all 0.3s;
-  user-select: none;
-}
-
-.fouls-badge:hover:not(.is-disabled) {
-  transform: scale(1.1);
-  box-shadow: 0 2px 8px rgba(64, 158, 255, 0.4);
-}
-
-.fouls-badge.is-warning {
-  background-color: #e6a23c;
-}
-
-.fouls-badge.is-warning:hover {
-  box-shadow: 0 2px 8px rgba(230, 162, 60, 0.4);
-}
-
-.fouls-badge.is-disabled {
-  background-color: #dcdfe6;
-  color: #909399;
-  cursor: not-allowed;
 }
 </style>

--- a/src/components/game/GameInProgress.vue
+++ b/src/components/game/GameInProgress.vue
@@ -10,7 +10,7 @@
           </div>
           <div class="header-right">
             <el-button
-              v-if="nextRoundButtonVisible"
+              v-if="nextRoundButtonVisible || gameFinished"
               type="primary"
               size="default"
               @click="handleNextRound"
@@ -41,20 +41,18 @@
       <GameTable :data="playersData" :row-class-name="getRowClassName">
         <el-table-column
           label="Фолы"
-          width="80"
+          width="120"
           align="center"
         >
           <template #default="{ row }">
-            <div
-              class="fouls-badge"
-              :class="{
-                'is-disabled': !row.is_in_game,
-                'is-warning': getCurrentFouls(row) > 2,
-              }"
-              @click.stop="handleFoulsClick(row)"
-            >
-              {{ getCurrentFouls(row) }}
-            </div>
+            <FoulBadges
+              :game-id="gameId"
+              :player="row"
+              :foul-types="foulTypes"
+              :fouls-summary="phaseData.fouls_summary"
+              @update:fouls-summary="phaseData.fouls_summary = $event"
+              @saved="refreshPlayersInGame"
+            />
           </template>
         </el-table-column>
 
@@ -75,9 +73,9 @@
           align="center"
         >
           <template #default="{ row }">
-            <div v-if="votingCompleted || (phaseData.removed_box_ids && phaseData.removed_box_ids.length > 0)">
+            <div v-if="votingCompleted || removedThisPhase">
               <span
-                v-if="phaseData.voted_box_ids.includes(row.box_id) || (phaseData.removed_box_ids && phaseData.removed_box_ids.includes(row.box_id))"
+                v-if="phaseData.voted_box_ids.includes(row.box_id) || phaseData.removed_box_ids.includes(row.box_id) || leftByFouls(row)"
                 class="left-game"
               >
                 покинул игру
@@ -117,9 +115,11 @@
       :nominated-players="nominatedPlayers"
       :players-data="playersData"
       :phase-data="phaseData"
+      :foul-types="foulTypes"
       @update:phase-data="phaseData = $event"
       @update:nominated-players="nominatedPlayers = $event"
       @voting-completed="handleVotingCompleted"
+      @fouls-saved="refreshPlayersInGame"
     />
 
     <NightActionsDialog
@@ -165,6 +165,7 @@ import { User, Close, Moon } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
 import GameTable from './GameTable.vue'
 import RoleColumn from './RoleColumn.vue'
+import FoulBadges from './FoulBadges.vue'
 import VotingDialog from './dialogs/VotingDialog.vue'
 import NightActionsDialog from './dialogs/NightActionsDialog.vue'
 import BestMoveDialog from './dialogs/BestMoveDialog.vue'
@@ -187,6 +188,9 @@ const emit = defineEmits(['round-completed'])
 const playersData = ref([])
 const phaseId = ref(null)
 const gameStatus = ref(null)
+
+// Типы фолов системы правил игры: [{ foul_type, removal_threshold }]
+const foulTypes = ref([{ foul_type: 'regular', removal_threshold: 4 }])
 
 // Массив для хранения box_id номинированных игроков в порядке выставления
 const nominatedPlayers = ref([])
@@ -242,10 +246,19 @@ const displayPhase = computed(() => {
   return phaseId.value
 })
 
+// Игрок выбыл по фолам в текущем круге: в снимке начала круга был в игре,
+// а после перечитывания состояния с сервера — уже нет
+const leftByFouls = (row) => row.was_in_game && !row.is_in_game
+
+// Есть ли выбывшие в текущем круге (ручное удаление или удаление по фолам)
+const removedThisPhase = computed(() => {
+  return phaseData.value.removed_box_ids.length > 0 || playersData.value.some(leftByFouls)
+})
+
 // Определяем, показывать ли кнопку "Начать голосование" или "Ночь"
 const showVotingButton = computed(() => {
   // Если есть удаленные игроки, не показываем кнопку голосования
-  if (phaseData.value.removed_box_ids && phaseData.value.removed_box_ids.length > 0) {
+  if (removedThisPhase.value) {
     return false
   }
   // Если phaseId == 1 и только один номинированный игрок - кнопка не показывается
@@ -396,81 +409,28 @@ const handleNextRound = async () => {
   }
 }
 
-// Получает текущее количество фолов для игрока
-const getCurrentFouls = (row) => {
-  // Ищем фолы в phaseData.fouls_summary
-  const foulEntry = phaseData.value.fouls_summary.find(f => f.box_id === row.box_id)
-  if (foulEntry) {
-    // Текущие фолы = исходные фолы + добавленные в этой фазе
-    return (row.fouls || 0) + foulEntry.count_fouls
-  }
-  return row.fouls || 0
-}
-
-// Обработчик клика по бейджу фолов
-const handleFoulsClick = async (row) => {
-  // Если игрок не в игре, ничего не делаем
-  if (!row.is_in_game) return
-
-  const currentFouls = getCurrentFouls(row)
-  const initialFouls = row.fouls || 0
-
-  // Вычисляем новое значение
-  let newTotalFouls
-  if (currentFouls === 4) {
-    // Если 4, сбрасываем на исходное значение
-    newTotalFouls = initialFouls
-  } else {
-    // Иначе увеличиваем до 4
-    newTotalFouls = currentFouls + 1
-  }
-
-  // Вычисляем count_fouls для phaseData.fouls_summary
-  const countFouls = newTotalFouls - initialFouls
-
-  // Обновляем или добавляем запись в fouls_summary
-  const existingIndex = phaseData.value.fouls_summary.findIndex(f => f.box_id === row.box_id)
-
-  if (countFouls === 0) {
-    // Если count_fouls равен 0, удаляем запись
-    if (existingIndex !== -1) {
-      phaseData.value.fouls_summary.splice(existingIndex, 1)
-    }
-  } else {
-    const foulEntry = {
-      box_id: row.box_id,
-      count_fouls: countFouls
-    }
-
-    if (existingIndex !== -1) {
-      // Обновляем существующую запись
-      phaseData.value.fouls_summary[existingIndex] = foulEntry
-    } else {
-      // Добавляем новую запись
-      phaseData.value.fouls_summary.push(foulEntry)
-    }
-  }
-
-  // Если игрок получил 4 фола, добавляем его в removed_box_ids
-  if (newTotalFouls === 4) {
-    if (!phaseData.value.removed_box_ids.includes(row.box_id)) {
-      phaseData.value.removed_box_ids.push(row.box_id)
-    }
-  } else {
-    // Если фолов меньше 4, удаляем из removed_box_ids
-    const removedIndex = phaseData.value.removed_box_ids.indexOf(row.box_id)
-    if (removedIndex !== -1) {
-      phaseData.value.removed_box_ids.splice(removedIndex, 1)
-    }
-  }
-
-  // Отправляем обновленные фолы на сервер
+// Удаление за фолы считает сервер: после сохранения фолов перечитываем
+// состояние игры и применяем is_in_game (фолы не трогаем — на клиенте они
+// равны снимку начала круга + дельте текущей фазы)
+let refreshSeq = 0
+const refreshPlayersInGame = async () => {
+  const seq = ++refreshSeq
   try {
-    await apiService.patchGamePhase(props.gameId, {
-      fouls_summary: [...phaseData.value.fouls_summary]
+    const gameState = await apiService.getGameState(props.gameId)
+    // Применяем только ответ последнего запроса
+    if (seq !== refreshSeq) return
+
+    const inGameByBox = new Map(gameState.players.map(p => [p.box_id, p.is_in_game]))
+    playersData.value.forEach(player => {
+      if (inGameByBox.has(player.box_id)) {
+        player.is_in_game = inGameByBox.get(player.box_id)
+      }
     })
+
+    // Удаление по фолам могло завершить игру (или откат фола — «раззавершить»)
+    gameFinished.value = FINISHED_GAME_RESULTS.includes(gameState.result)
   } catch (error) {
-    console.error('Failed to patch fouls_summary:', error)
+    console.error('Failed to refresh game state after fouls update:', error)
   }
 }
 
@@ -489,16 +449,27 @@ const loadGameData = async () => {
     phaseId.value = gameState.phase_id
     gameStatus.value = gameState.result
 
+    // Типы фолов и пороги удаления — из системы правил игры
+    if (gameState.rule_system?.removal_thresholds?.length) {
+      foulTypes.value = gameState.rule_system.removal_thresholds
+    }
+
     // Преобразуем данные игроков в формат для таблицы
     if (gameState.players && Array.isArray(gameState.players)) {
-      playersData.value = gameState.players.map(player => ({
-        id: player.id,
-        nickname: player.nickname,
-        box_id: player.box_id,
-        role: player.role || GameRolesEnum.civilian,
-        fouls: player.fouls || 0,
-        is_in_game: player.is_in_game !== undefined ? player.is_in_game : true
-      }))
+      playersData.value = gameState.players.map(player => {
+        const isInGame = player.is_in_game !== undefined ? player.is_in_game : true
+        return {
+          id: player.id,
+          nickname: player.nickname,
+          box_id: player.box_id,
+          role: player.role || GameRolesEnum.civilian,
+          // Снимок фолов по типам на начало круга: [{ type, count }]
+          fouls: player.fouls || [],
+          is_in_game: isInGame,
+          // Снимок для определения выбывших в текущем круге
+          was_in_game: isInGame
+        }
+      })
     }
   } catch (error) {
     console.error('Failed to load game state:', error)
@@ -579,44 +550,6 @@ defineExpose({
   font-weight: normal;
 }
 
-.fouls-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 24px;
-  height: 24px;
-  padding: 0 8px;
-  background-color: #409eff;
-  color: white;
-  border-radius: 12px;
-  font-weight: 600;
-  font-size: 14px;
-  cursor: pointer;
-  transition: all 0.3s;
-  user-select: none;
-  position: relative;
-  z-index: 9999;
-}
-
-.fouls-badge:hover:not(.is-disabled) {
-  transform: scale(1.1);
-  box-shadow: 0 2px 8px rgba(64, 158, 255, 0.4);
-}
-
-.fouls-badge.is-warning {
-  background-color: #e6a23c;
-}
-
-.fouls-badge.is-warning:hover {
-  box-shadow: 0 2px 8px rgba(230, 162, 60, 0.4);
-}
-
-.fouls-badge.is-disabled {
-  background-color: #dcdfe6;
-  color: #909399;
-  cursor: not-allowed;
-}
-
 :deep(.el-table .el-table__row) {
   height: 48px;
 }
@@ -628,6 +561,11 @@ defineExpose({
 :deep(.inactive-player) {
   opacity: 0.5;
   pointer-events: none;
+}
+
+/* Бейджи фолов кликабельны и у выбывшего — для отката фолов текущей фазы */
+:deep(.inactive-player .foul-badges) {
+  pointer-events: auto;
 }
 
 :deep(.inactive-player td) {

--- a/src/components/game/dialogs/VotingDialog.vue
+++ b/src/components/game/dialogs/VotingDialog.vue
@@ -10,7 +10,9 @@
         :game-id="props.gameId"
         :players-data="props.playersData"
         :phase-data="props.phaseData"
+        :foul-types="props.foulTypes"
         @update:phase-data="emit('update:phaseData', $event)"
+        @saved="emit('fouls-saved')"
       />
 
       <el-divider />
@@ -134,10 +136,14 @@ const props = defineProps({
   phaseData: {
     type: Object,
     default: () => ({})
+  },
+  foulTypes: {
+    type: Array,
+    default: () => []
   }
 })
 
-const emit = defineEmits(['update:modelValue', 'update:phaseData', 'update:nominatedPlayers', 'voting-completed'])
+const emit = defineEmits(['update:modelValue', 'update:phaseData', 'update:nominatedPlayers', 'voting-completed', 'fouls-saved'])
 
 const votes = reactive({})
 const votingRound = ref(1)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -14,12 +14,6 @@ export const PLAYER_ROLES = {
     DON: 'Дон'
 }
 
-// Максимальные фолы
-export const MAX_FOULS = {
-    BEFORE_SILENCE: 3,
-    BEFORE_ELIMINATION: 4
-}
-
 // Статусы игры
 export const GAME_STATUSES = {
     CREATED: 'created',

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -132,12 +132,6 @@ export const formatVoteCount = (count) => {
   return `${count} ${voteWord}`
 }
 
-// Форматирование количества фолов
-export const formatFoulCount = (count) => {
-  const foulWord = pluralize(count, ['фол', 'фола', 'фолов'])
-  return `${count} ${foulWord}`
-}
-
 // Форматирование списка имен
 export const formatNamesList = (names, maxVisible = 3) => {
   if (!Array.isArray(names) || names.length === 0) return ''

--- a/src/utils/gameConstants.js
+++ b/src/utils/gameConstants.js
@@ -17,15 +17,6 @@ export const GAME_RULES = {
     SHERIFF: 1
   },
   
-  // Правила фолов
-  FOULS: {
-    WARNING_THRESHOLD: 2,      // После 2 фолов - предупреждение
-    SILENCE_THRESHOLD: 3,      // После 3 фолов - лишение права голоса
-    ELIMINATION_THRESHOLD: 4,  // После 4 фолов - удаление из игры
-    MAX_ALLOWED: 4,           // Максимальное количество фолов
-    TECHNICAL_DEFEAT: 5       // Техническое поражение команды
-  },
-  
   // Раунды и фазы
   ROUNDS: {
     CRITICAL_ROUNDS_LIMIT: 3,    // После 3 раундов без выбывших - критические раунды
@@ -147,17 +138,6 @@ export const PLAYER_ACTIONS = {
   CHECK: 'check',
   BEST_MOVE: 'best_move',
   PASS: 'pass'
-}
-
-// Типы фолов
-export const FOUL_TYPES = {
-  SPEAKING_OUT_OF_TURN: 'speaking_out_of_turn',
-  GESTURES: 'gestures',
-  REVEALING_ROLE: 'revealing_role',
-  SWEARING: 'swearing',
-  DELAY_OF_GAME: 'delay_of_game',
-  TOUCHING_PLAYERS: 'touching_players',
-  OTHER: 'other'
 }
 
 // Результаты проверок

--- a/src/utils/playerHelpers.js
+++ b/src/utils/playerHelpers.js
@@ -15,15 +15,9 @@ export const isPlayerAlive = (player) => {
   return player.status === 'alive' && !player.isEliminated && !player.isDead
 }
 
-// Проверка, может ли игрок говорить
-export const canPlayerSpeak = (player) => {
-  if (!player) return false
-  return isPlayerAlive(player) && player.fouls < GAME_RULES.FOULS.SILENCE_THRESHOLD
-}
-
 // Проверка, может ли игрок голосовать
 export const canPlayerVote = (player) => {
-  return canPlayerSpeak(player) // Те же условия, что и для речи
+  return isPlayerAlive(player)
 }
 
 // Получение отображаемого имени игрока
@@ -56,32 +50,14 @@ export const isPlayerCivilian = (player) => {
   return getPlayerTeam(role) === 'red'
 }
 
-// Получение количества фолов игрока
-export const getPlayerFouls = (player) => {
-  return player?.fouls || 0
-}
-
-// Проверка, удален ли игрок за фолы
-export const isPlayerEliminatedByFouls = (player) => {
-  return getPlayerFouls(player) >= GAME_RULES.FOULS.ELIMINATION_THRESHOLD
-}
-
-// Проверка, лишен ли игрок права голоса
-export const isPlayerSilenced = (player) => {
-  const fouls = getPlayerFouls(player)
-  return fouls >= GAME_RULES.FOULS.SILENCE_THRESHOLD && 
-         fouls < GAME_RULES.FOULS.ELIMINATION_THRESHOLD
-}
-
 // Получение статуса игрока
 export const getPlayerStatus = (player) => {
   if (!player) return 'unknown'
-  
+
   if (player.isDead) return 'dead'
-  if (player.isEliminated || isPlayerEliminatedByFouls(player)) return 'eliminated'
-  if (isPlayerSilenced(player)) return 'silenced'
+  if (player.isEliminated) return 'eliminated'
   if (player.status === 'alive') return 'alive'
-  
+
   return player.status || 'unknown'
 }
 

--- a/src/utils/uiConstants.js
+++ b/src/utils/uiConstants.js
@@ -54,8 +54,7 @@ export const UI_MESSAGES = {
     VOTE_RECORDED: 'Голос учтен',
     ACTION_COMPLETED: 'Действие выполнено',
     PLAYER_ELIMINATED: 'Игрок удален',
-    FOUL_ADDED: 'Фол добавлен',
-    
+
     // События
     EVENT_CREATED: 'Мероприятие создано',
     EVENT_UPDATED: 'Мероприятие обновлено',
@@ -71,9 +70,7 @@ export const UI_MESSAGES = {
     
     // Игроки
     ELIMINATE_PLAYER: 'Удалить игрока {name} из игры?',
-    ADD_FOUL: 'Добавить фол игроку {name}?',
-    REMOVE_FOUL: 'Снять фол с игрока {name}?',
-    
+
     // Действия
     CONFIRM_VOTE: 'Подтвердить голосование?',
     CONFIRM_KILL: 'Подтвердить убийство игрока {name}?',
@@ -89,7 +86,6 @@ export const UI_MESSAGES = {
   // Предупреждения
   WARNINGS: {
     UNSAVED_CHANGES: 'Есть несохраненные изменения',
-    FOUL_LIMIT: 'У игрока {name} максимальное количество фолов',
     CRITICAL_ROUNDS: 'Включен режим критических раундов',
     LOW_TIME: 'Осталось мало времени',
     NO_CANDIDATES: 'Нет кандидатов на выбывание'
@@ -140,15 +136,6 @@ export const COLORS = {
     DRAW: '#e6a23c',        // Ничья
     IN_PROGRESS: '#409eff', // В процессе
     CANCELLED: '#909399'    // Отменена
-  },
-  
-  // Цвета фолов
-  FOULS: {
-    0: '#67c23a',           // Нет фолов
-    1: '#e6a23c',           // 1 фол
-    2: '#ff9800',           // 2 фола
-    3: '#f56c6c',           // 3 фола
-    4: '#d32f2f'            // 4 фола
   },
   
   // UI цвета
@@ -215,7 +202,6 @@ export const TEXT_TEMPLATES = {
   // Игроки
   PLAYER_NUMBER: 'Игрок №{number}',
   PLAYER_ROLE: '{name} - {role}',
-  PLAYER_FOULS: 'Фолы: {count}',
   
   // Голосование
   VOTE_COUNT: 'Голосов: {count}',
@@ -246,7 +232,6 @@ export const PLACEHOLDERS = {
   // Комментарии
   COMMENT: 'Добавить комментарий...',
   SCORE_COMMENT: 'Комментарий к баллам (например: "Лучший ход в 3-м раунде")',
-  FOUL_REASON: 'Причина фола...',
   
   // События
   EVENT_NAME: 'Название мероприятия',

--- a/src/views/GameDiesView.vue
+++ b/src/views/GameDiesView.vue
@@ -92,7 +92,12 @@
             <span class="player-nickname" v-fit-text>{{ player.nickname }}</span>
             <span class="player-status">
               <template v-if="player.is_in_game">
-                <span v-if="player.fouls > 0" class="fouls">{{ '!'.repeat(player.fouls) }}</span>
+                <span
+                  v-for="foul in playerFouls(player)"
+                  :key="foul.type"
+                  class="fouls"
+                  :class="'fouls-' + foul.type"
+                >{{ foulMarks(foul) }}</span>
               </template>
               <template v-else>
                 <img
@@ -306,6 +311,17 @@ const roleComponentMap = {
 
 const roleIconComponent = (role) => {
   return roleComponentMap[role] || IconCivilian
+}
+
+// Фолы игрока по типам (только ненулевые): [{ type, count }]
+const playerFouls = (player) => {
+  return (player.fouls || []).filter(f => f.count > 0)
+}
+
+// Обычные фолы — «!», прочие типы — первая буква названия (t для tech)
+const foulMarks = (foul) => {
+  const mark = foul.type === 'regular' ? '!' : foul.type[0]
+  return mark.repeat(foul.count)
 }
 
 const leaveReasonIcons = {
@@ -641,6 +657,14 @@ html:has(.dies-overlay) #app {
 .fouls {
   color: #ff5252;
   text-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
+}
+
+.fouls-tech {
+  color: #b37feb;
+}
+
+.fouls + .fouls {
+  margin-left: 4px;
 }
 
 .leave-icon-img {


### PR DESCRIPTION
- send required foul type in fouls_summary entries, read per-type fouls [{type, count}] from game state and dies subscription
- render a badge per foul type from rule_system.removal_thresholds (colors + type letter + tooltip), warning highlight from threshold
- drop client-side removal at 4 fouls: refetch game state after each fouls PATCH and apply server is_in_game; badge stays clickable for a foul-removed player to revert current-phase fouls
- unify duplicated fouls logic into FoulBadges.vue used by both the game table column and FoulsPanel
- remove dead foul constants/helpers

Closes #61 